### PR TITLE
Fixed wrong URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## To use
 
 ```sh
-git clone https://github.com/pjsier/blendbook.git
+git clone https://github.com/andyras/edumap.git
 cd edumap/edumap
 gem install bundler
 bundle install


### PR DESCRIPTION
Just realized I had the wrong clone URL in the README.md from a different project. Sorry about that