### PR TITLE
Fix bug that caused with_grade scope not to work properly

### DIFF
--- a/edumap/app/models/lesson.rb
+++ b/edumap/app/models/lesson.rb
@@ -36,13 +36,8 @@ class Lesson < ActiveRecord::Base
 
   scope :with_standard, -> (standards) { with_association(:standards, standards) }
   scope :with_grade, -> (level) do
-    grade_at_most(level).grade_at_least(level)
-  end
-  scope :grade_at_most, -> (level) do
     where(id: joins(:levels).where("levels.id <= ?", level))
-  end
-  scope :grade_at_least, -> (level) do
-    where(id: joins(:levels).where("levels.id >= ?", level))
+      .where(id: joins(:levels).where("levels.id >= ?", level))
   end
   scope :with_association, -> (assoc, assoc_ids) do
     joins(assoc).where(assoc => {id: assoc_ids}).group("lessons.id")

--- a/edumap/app/models/lesson.rb
+++ b/edumap/app/models/lesson.rb
@@ -36,10 +36,13 @@ class Lesson < ActiveRecord::Base
 
   scope :with_standard, -> (standards) { with_association(:standards, standards) }
   scope :with_grade, -> (level) do
-    has_level_in_range(0..level).has_level_in_range(level..13)
+    grade_at_most(level).grade_at_least(level)
   end
-  scope :has_level_in_range, -> (range) do
-    where(id: joins(:levels).where(levels: { id: range } ))
+  scope :grade_at_most, -> (level) do
+    where(id: joins(:levels).where("levels.id <= ?", level))
+  end
+  scope :grade_at_least, -> (level) do
+    where(id: joins(:levels).where("levels.id >= ?", level))
   end
   scope :with_association, -> (assoc, assoc_ids) do
     joins(assoc).where(assoc => {id: assoc_ids}).group("lessons.id")

--- a/edumap/app/models/lesson.rb
+++ b/edumap/app/models/lesson.rb
@@ -35,7 +35,12 @@ class Lesson < ActiveRecord::Base
   scope :with_created_at_gte, -> (ref_date) { where('created_at >= ?', ref_date) }
 
   scope :with_standard, -> (standards) { with_association(:standards, standards) }
-  scope :with_grade, -> (levels) { with_association(:levels, levels) }
+  scope :with_grade, -> (level) do
+    has_level_in_range(0..level).has_level_in_range(level..13)
+  end
+  scope :has_level_in_range, -> (range) do
+    where(id: joins(:levels).where(levels: { id: range } ))
+  end
   scope :with_association, -> (assoc, assoc_ids) do
     joins(assoc).where(assoc => {id: assoc_ids}).group("lessons.id")
   end

--- a/edumap/test/fixtures/levels.yml
+++ b/edumap/test/fixtures/levels.yml
@@ -9,3 +9,5 @@ one: {}
 #
 two: {}
 #  column: value
+three: {}
+four: {}

--- a/edumap/test/models/lesson_test.rb
+++ b/edumap/test/models/lesson_test.rb
@@ -86,4 +86,3 @@ class LessonTestSorting < ActiveSupport::TestCase
     assert_equal (Lesson.sorted_by :created_at_bob), [first, second]
   end
 end
-

--- a/edumap/test/models/lesson_test.rb
+++ b/edumap/test/models/lesson_test.rb
@@ -55,10 +55,17 @@ class LessonTestScopes < ActiveSupport::TestCase
     assert_equal (Lesson.with_standard standards(:defence).id), [in_scope]
   end
 
-  test "it scopes to the grade" do
+  test "it scopes to the grade when a matching level is present" do
     in_scope = Lesson.create!(levels: [levels(:one)])
     out_of_scope = Lesson.create!(levels: [levels(:two)])
     assert_equal (Lesson.with_grade levels(:one).id), [in_scope]
+  end
+
+  test "it scopes to the grade when a matching range of levels is present" do
+    [levels(:one), levels(:two), levels(:three), levels(:four)].each(&:touch)
+    in_scope = Lesson.create!(levels: [levels(:one), levels(:three)])
+    out_of_scope = Lesson.create!(levels: [levels(:three), levels(:four)])
+    assert_equal (Lesson.with_grade levels(:two).id), [in_scope]
   end
 
   test "it groups by the lesson id" do


### PR DESCRIPTION
`with_grade` will now find all lessons with grade ranges containing the specified grade. @hwayne 