### PR TITLE
Add filter option for plugged or unplugged lessons

### DIFF
--- a/edumap/app/controllers/lessons_controller.rb
+++ b/edumap/app/controllers/lessons_controller.rb
@@ -7,7 +7,8 @@ class LessonsController < ApplicationController
       :select_options => {
         sorted_by: Lesson.options_for_sorted_by,
         with_standard: Standard.options_for_select,
-        with_grade: Level.options_for_select
+        with_grade: Level.options_for_select,
+        with_plugged: [["Yes", true], ["No", false]]
       }
     ) or return
     @lessons = @filterrific.find.page(params[:page])

--- a/edumap/app/models/lesson.rb
+++ b/edumap/app/models/lesson.rb
@@ -6,6 +6,7 @@ class Lesson < ActiveRecord::Base
                   with_standard
                   with_grade
                   with_created_at_gte
+                  with_plugged
                 ]
 
   self.per_page = 10
@@ -42,6 +43,7 @@ class Lesson < ActiveRecord::Base
   scope :with_association, -> (assoc, assoc_ids) do
     joins(assoc).where(assoc => {id: assoc_ids}).group("lessons.id")
   end
+  scope :with_plugged, -> (value) { where(plugged?: value) }
 
   scope :sorted_by, -> sort_option do
     # extract the sort direction from the param value.

--- a/edumap/app/views/layouts/application.html.haml
+++ b/edumap/app/views/layouts/application.html.haml
@@ -43,6 +43,13 @@
                           { :include_blank => '- Any -' },
                           { :class => 'form-control' }
             .row
+              .form-group.chardin_box{ :'data-position' => 'top', :'data-intro' => 'Filter by pluggedness.' }
+                %label Computer required?
+                = f.select :with_plugged,
+                          @filterrific.select_options[:with_plugged],
+                          { :include_blank => '- Any -' },
+                          { :class => 'form-control' }
+            .row
               .form-group.chardin_box{ :'data-position' => 'top', :'data-intro' => 'Change the sorting.' }
                 %label Sorted by
                 = f.select :sorted_by,

--- a/edumap/test/models/lesson_test.rb
+++ b/edumap/test/models/lesson_test.rb
@@ -78,6 +78,12 @@ class LessonTestScopes < ActiveSupport::TestCase
     out_of_scope = Lesson.create!(created_at: 3.day.ago)
     assert_equal (Lesson.with_created_at_gte 2.days.ago), [in_scope]
   end
+
+  test "it scopes by plugged versus unplugged" do
+    in_scope = Lesson.create!(plugged?: false)
+    out_of_scope = Lesson.create!(plugged?: true)
+    assert_equal Lesson.with_plugged(false), [in_scope]
+  end
 end
 
 class LessonTestSorting < ActiveSupport::TestCase


### PR DESCRIPTION
Lessons can now be filtered by plugged/unplugged status.

![screen shot 2016-03-08 at 8 27 19 pm](https://cloud.githubusercontent.com/assets/8214544/13623422/35c320e4-e56c-11e5-8ed4-2cdf310b7809.png)
