### PR TITLE
Add ability to select, save, and load lessons

### DIFF
--- a/edumap/Gemfile
+++ b/edumap/Gemfile
@@ -16,6 +16,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
+gem 'js-routes'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/edumap/Gemfile.lock
+++ b/edumap/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    js-routes (1.2.4)
+      railties (>= 3.2)
+      sprockets-rails
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -191,6 +194,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  js-routes
   pg
   rails (= 4.2.4)
   sass-rails (~> 5.0)

--- a/edumap/app/assets/javascripts/application.js
+++ b/edumap/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require bootstrap-sprockets
 //= require jquery_ujs
 //= require turbolinks
+//= require js-routes
 //= require_tree .
 
 //= require bootstrap-datepicker/core

--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -4,10 +4,18 @@
 
 
 $(document).ready =>
-  $(document).on("change",".lesson-checkbox", ->
+  $("table.table").on("change",".lesson-checkbox", (event)->
+    that = $(this)[0]
+    event.preventDefault()
     lesson_id = $(this).attr('data-lesson-id')
-    if $(this).is(':checked')
+    if this.checked
       $.post Routes.add_lesson_path(lesson_id)
+      .fail(
+        (response) -> alert "Your choice could not be saved."
+        that.checked = false)
     else
       $.post Routes.remove_lesson_path(lesson_id)
+      .fail(
+        (response) -> alert "Your choice could not be saved."
+        that.checked = true)
 )

--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -4,7 +4,7 @@
 
 
 $(document).ready =>
-  $("table.table").on("change",".lesson-checkbox", (event)->
+  $("table.table").on("change",".lesson-checkbox", (event) ->
     that = $(this)[0]
     event.preventDefault()
     lesson_id = $(this).attr('data-lesson-id')

--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -1,3 +1,9 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+
+$(document).ready =>
+  $(document).on "click", ".foo", (e) =>
+    $.post Routes.add_lesson_path(1),
+      success: -> alert "successful!"

--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -4,6 +4,10 @@
 
 
 $(document).ready =>
-  $(document).on "click", ".foo", (e) =>
-    $.post Routes.add_lesson_path(1),
-      success: -> alert "successful!"
+  $(document).on("change",".lesson-checkbox", ->
+    lesson_id = $(this).attr('data-lesson-id')
+    if $(this).is(':checked')
+      $.post Routes.add_lesson_path(lesson_id)
+    else
+      $.post Routes.remove_lesson_path(lesson_id)
+)

--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -11,11 +11,15 @@ $(document).ready =>
     if this.checked
       $.post Routes.add_lesson_path(lesson_id)
       .fail(
-        (response) -> alert "Your choice could not be saved."
-        that.checked = false)
+        (response) ->
+          alert "Your choice could not be saved."
+          that.checked = false
+          return)
     else
       $.post Routes.remove_lesson_path(lesson_id)
       .fail(
-        (response) -> alert "Your choice could not be saved."
-        that.checked = true)
+        (response) ->
+          alert "Your choice could not be saved."
+          that.checked = true
+          return)
 )

--- a/edumap/app/controllers/lessons_controller.rb
+++ b/edumap/app/controllers/lessons_controller.rb
@@ -17,4 +17,24 @@ class LessonsController < ApplicationController
       format.js
     end
   end
+
+  def load_lessons
+    session[:lessons] = params[:lessons]
+    redirect_to :saved_lessons
+  end
+
+  def saved_lessons
+    @filterrific = initialize_filterrific(
+      Lesson.where(id: session[:lessons]),
+      params[:filterrific],
+      :select_options => {
+        sorted_by: Lesson.options_for_sorted_by,
+        with_standard: Standard.options_for_select,
+        with_grade: Level.options_for_select
+      }
+    ) or return
+    @lessons = @filterrific.find.page(params[:page])
+
+    render :index
+  end
 end

--- a/edumap/app/controllers/sessions_controller.rb
+++ b/edumap/app/controllers/sessions_controller.rb
@@ -1,0 +1,22 @@
+class SessionsController < ApplicationController
+  def add_lesson
+    lessons.push(lesson).uniq!
+    render status: :ok, json: lessons.to_a
+  end
+
+  def remove_lesson
+    lessons.delete(lesson)
+    render status: :ok, json: lessons.to_a
+  end
+
+  protected
+
+  def lessons
+    session[:lessons] ||= []
+  end
+
+  def lesson
+    params[:lesson]
+  end
+end
+

--- a/edumap/app/helpers/lessons_helper.rb
+++ b/edumap/app/helpers/lessons_helper.rb
@@ -1,2 +1,5 @@
 module LessonsHelper
+  def in_session?(id)
+    session[:lessons].include? id
+  end
 end

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -9,14 +9,15 @@
 
 %table.table
   %tr
-    %th Foo
+    %th Select
     %th Curriculum
     %th Lesson
     %th Time
     %th Level
   - lessons.each do |lesson|
     %tr.accordion-toggle{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}
-      %td.btn.foo= "foo"
+      %td
+        %input.lesson-checkbox{type: "checkbox", checked: in_session?("#{lesson.id}"), data: {lesson_id: "#{lesson.id}"}}
       %td= lesson.curriculum.name
       %td= link_to lesson.name, lesson.lesson_url, :target => "_blank"
       %td= lesson.time

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -9,12 +9,14 @@
 
 %table.table
   %tr
+    %th Foo
     %th Curriculum
     %th Lesson
     %th Time
     %th Level
   - lessons.each do |lesson|
     %tr.accordion-toggle{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}
+      %td.btn.foo= "foo"
       %td= lesson.curriculum.name
       %td= link_to lesson.name, lesson.lesson_url, :target => "_blank"
       %td= lesson.time

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -15,13 +15,13 @@
     %th Time
     %th Level
   - lessons.each do |lesson|
-    %tr.accordion-toggle{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}
+    %tr.accordion-toggle
       %td
         %input.lesson-checkbox{type: "checkbox", checked: in_session?("#{lesson.id}"), data: {lesson_id: "#{lesson.id}"}}
-      %td= lesson.curriculum.name
-      %td= link_to lesson.name, lesson.lesson_url, :target => "_blank"
-      %td= lesson.time
-      %td= lesson.level_list
+      %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.curriculum.name
+      %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= link_to lesson.name, lesson.lesson_url, :target => "_blank"
+      %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.time
+      %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.level_list
     %tr.accordion-body.collapse{:id => "#{lesson.id}"}
       %td
         - if lesson.plugged?

--- a/edumap/config/routes.rb
+++ b/edumap/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'lessons#index'
+  post 'sessions/add_lesson/:lesson' => 'sessions#add_lesson', as: :add_lesson
+  post 'sessions/remove_lesson/:lesson' => 'sessions#remove_lesson', as: :remove_lesson
 
 
   # Example of regular route:

--- a/edumap/config/routes.rb
+++ b/edumap/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'lessons#index'
+
+  get 'lessons/saved_lessons' => 'lessons#saved_lessons', as: :saved_lessons
+  get 'lessons/load_lessons' => 'lessons#load_lessons', as: :load_lessons
+
   post 'sessions/add_lesson/:lesson' => 'sessions#add_lesson', as: :add_lesson
   post 'sessions/remove_lesson/:lesson' => 'sessions#remove_lesson', as: :remove_lesson
 

--- a/edumap/test/controllers/lessons_controller_test.rb
+++ b/edumap/test/controllers/lessons_controller_test.rb
@@ -1,7 +1,13 @@
 require 'test_helper'
 
 class LessonsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "load_lessons redirects to saved_lessons" do
+     get(:load_lessons, lessons: [2, 3, 4, 5, 6])
+     assert_redirected_to :saved_lessons
+  end
+
+  test "load_lessons adds the lesson ids to the session" do
+     get(:load_lessons, lessons: [2, 3])
+     assert_equal session[:lessons], ['2', '3']
+  end
 end

--- a/edumap/test/controllers/sessions_controller_test.rb
+++ b/edumap/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,26 @@
+class SessionsControllerTest < ActionController::TestCase
+   test "add_lesson adds the lesson id to the session" do
+     post(:add_lesson, lesson: 2)
+     assert_includes session[:lessons], '2'
+   end
+
+   test "add_lesson does not add duplicate lessons" do
+     post(:add_lesson, lesson: 2)
+     post(:add_lesson, lesson: 2)
+     assert_equal session[:lessons], ['2']
+   end
+
+   test "remove_lesson removes the lesson id to the session" do
+     session[:lessons] = ["2"]
+     post(:remove_lesson, lesson: 2)
+     assert_not_includes session[:lessons], '2'
+   end
+
+   test "response includes array of all remaining lesson ids" do
+     post(:add_lesson, lesson: 2)
+     assert_equal @response.body, ["2"].to_json
+   end
+end
+
+class LoadSessionsTest < ActionController::TestCase
+end


### PR DESCRIPTION
This PR adds a checkbox to select lessons for later emailing. One selected, it stores the lesson's id in a session variable so that selections persist across pages. The `lessons/saved_lessons` route will show all saved lessons, while the `lessons/load_lesson` route will allow people to restore saved lessons from a link, paving the way to include "resume session" links in the emails.

The email backend is not implemented because it's dependent on #60. The email frontend is not implemented because I'm the worst at front end.