### PR TITLE
Added blank check to LessonHelper

### DIFF
--- a/edumap/app/helpers/lessons_helper.rb
+++ b/edumap/app/helpers/lessons_helper.rb
@@ -1,5 +1,7 @@
 module LessonsHelper
   def in_session?(id)
-    session[:lessons].include? id
+    unless session[:lessons].blank?
+      session[:lessons].include? id
+    end
   end
 end


### PR DESCRIPTION
Index page was throwing an error if no lesson was checked. Added a `blank?` check to make sure it's not empty, otherwise still check any lessons that are in the session