### PR TITLE
bind "save lesson" checkbox to document

### DIFF
--- a/edumap/app/assets/javascripts/lessons.coffee
+++ b/edumap/app/assets/javascripts/lessons.coffee
@@ -4,7 +4,7 @@
 
 
 $(document).ready =>
-  $("table.table").on("change",".lesson-checkbox", (event) ->
+  $(document).on("change",".lesson-checkbox", (event) ->
     that = $(this)[0]
     event.preventDefault()
     lesson_id = $(this).attr('data-lesson-id')


### PR DESCRIPTION
Before the "save lesson" checkbox was bound to `table.table`, which broke when you clicked on a pagination button. Switching to `document` fixes this bug.