### PR TITLE
Improve contact form styling; add links to Contact and About pages

### DIFF
--- a/edumap/app/assets/stylesheets/contact.scss
+++ b/edumap/app/assets/stylesheets/contact.scss
@@ -1,0 +1,3 @@
+.main-content-form {
+  margin-bottom: 20px;
+}

--- a/edumap/app/views/contact/new.html.haml
+++ b/edumap/app/views/contact/new.html.haml
@@ -2,13 +2,21 @@
 .row
   .col-md-10.col-sm-12.col-md-offset-1
     %h2= t('.contact_us')
-    = simple_form_for @contact, :url => contact_path do |f|
+    = simple_form_for @contact, :url => contact_path, :html => { :class => "main-content-form" } do |f|
       .row
         .col-sm-12.col-md-3
           = f.input :name, :label => t('.name')
         .col-sm-12.col-md-3
           = f.input :email, :label => t('.email')
-      = f.input :subject, :label => t('.subject')
-      = f.input :message, :as => :text, :label => t('.message')
-      = f.input :url, :as => :string, :label => t('.url')
-      = f.button :submit, {:value => "Submit"}
+      .row
+        .col-sm-12.col-md-6
+          = f.input :subject, :label => t('.subject')
+      .row
+        .col-sm-12.col-md-6
+          = f.input :message, :as => :text, :label => t('.message')
+      .row
+        .col-sm-12.col-md-6
+          = f.input :url, :as => :string, :label => t('.url')
+      .row
+        .col-sm-12.col-md-6
+          = f.button :submit, { :value => "Submit" }

--- a/edumap/app/views/layouts/application.html.haml
+++ b/edumap/app/views/layouts/application.html.haml
@@ -28,5 +28,8 @@
     = yield
     %footer
       %p
-        Made with &#10084; by the Teach Tech Taskforce at
+        = link_to "About", "#"
+        | Made with &#10084; by the Teach Tech Taskforce at
         %a{:href => "https://chihacknight.org/"} ChiHackNight
+        |
+        = link_to "Contact Us", contact_path

--- a/edumap/config/initializers/simple_form_bootstrap.rb
+++ b/edumap/config/initializers/simple_form_bootstrap.rb
@@ -1,0 +1,149 @@
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  config.error_notification_class = 'alert alert-danger'
+  config.button_class = 'btn btn-default'
+  config.boolean_label_class = nil
+
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'checkbox' do |ba|
+      ba.use :label_input
+    end
+
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'col-sm-offset-3 col-sm-9' do |wr|
+      wr.wrapper tag: 'div', class: 'checkbox' do |ba|
+        ba.use :label_input
+      end
+
+      wr.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      wr.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'sr-only'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.wrapper tag: 'div', class: 'form-inline' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+  # Wrappers for forms and inputs using the Bootstrap toolkit.
+  # Check the Bootstrap docs (http://getbootstrap.com)
+  # to learn about the different styles for forms and inputs,
+  # buttons and other elements.
+  config.default_wrapper = :vertical_form
+  config.wrapper_mappings = {
+    check_boxes: :vertical_radio_and_checkboxes,
+    radio_buttons: :vertical_radio_and_checkboxes,
+    file: :vertical_file_input,
+    boolean: :vertical_boolean,
+    datetime: :multi_select,
+    date: :multi_select,
+    time: :multi_select
+  }
+end


### PR DESCRIPTION
Reinstalled `simple_form` with `--bootstrap` on, so the correct CSS is present. Added links at bottom of layout.

Note that the "About" link doesn't currently lead anywhere; the route is in a separate PR, and in any case the page has no content yet.

![screen shot 2016-05-24 at 8 46 03 pm](https://cloud.githubusercontent.com/assets/8214544/15525585/eb35b552-21f0-11e6-9818-4c69ce968a15.png)
![screen shot 2016-05-24 at 8 45 53 pm](https://cloud.githubusercontent.com/assets/8214544/15525586/ef021ab8-21f0-11e6-8260-f617ff0896fe.png)
