### PR TITLE
About Page Additions

### DIFF
--- a/edumap/app/assets/stylesheets/layout.scss
+++ b/edumap/app/assets/stylesheets/layout.scss
@@ -153,10 +153,45 @@ div.about{
   padding-bottom: 15px;
 }
 
+div.about h1{
+  text-align: center;
+}
+
 div.about p{
   text-align: center;
 }
 
+div.contributor-grid{
+  width: 95%;
+  display: block;
+  margin: 0 auto;
+  font-size: 0;
+  text-align: center;
+}
+
+div.contributor{
+  display: inline-block;
+  width: 180px;
+  height: 40px;
+  margin: 10px 0;
+  text-align: left;
+}
+
+div.contributor img, div.contributor h4{
+  height: 40px;
+  display: inline-block;
+  vertical-align: top;
+}
+
+div.contributor img{
+  width: 40px;
+  border-radius: 20px;
+}
+
+div.contributor h4{
+  font-size: 15px;
+  margin: 10px;
+}
 
 //pagination
 

--- a/edumap/app/assets/stylesheets/layout.scss
+++ b/edumap/app/assets/stylesheets/layout.scss
@@ -157,8 +157,10 @@ div.about h1{
   text-align: center;
 }
 
-div.about p{
-  text-align: center;
+div.about p, div.about ul{
+  display: block;
+  margin: 15px auto;
+  width: 95%;
 }
 
 div.contributor-grid{

--- a/edumap/app/views/static_pages/about.html.haml
+++ b/edumap/app/views/static_pages/about.html.haml
@@ -2,8 +2,10 @@
     %p
         Check us out on
         %a{:href => "https://github.com/andyras/edumap"} GitHub!
-    %h2
+    %h1
         Contributors
+    %p
+        Thank you to all the designers, developers, and educators who have given their blood, sweat, and code to create EduMap!
     %div.contributor-grid
         %div.contributor
             %img{:src =>'https://chihacknight.org/images/people/andy-rasmussen.jpg'}

--- a/edumap/app/views/static_pages/about.html.haml
+++ b/edumap/app/views/static_pages/about.html.haml
@@ -2,3 +2,94 @@
     %p
         Check us out on
         %a{:href => "https://github.com/andyras/edumap"} GitHub!
+    %h2
+        Contributors
+    %div.contributor-grid
+        %div.contributor
+            %img{:src =>'https://chihacknight.org/images/people/andy-rasmussen.jpg'}
+            %h4
+                Andy Rasmussen
+        %div.contributor
+            %img{:src =>'https://avatars2.githubusercontent.com/u/11791558?v=3&s=460'}
+            %h4
+                Anda Cabrera
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/2112037?v=3&s=460'}
+            %h4
+                Andrew Carr
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/13334214?v=3&s=460'}
+            %h4
+                Becca Nelson
+        %div.contributor
+            %img{:src =>'https://avatars2.githubusercontent.com/u/12089069?v=3&s=460'}
+            %h4
+                Bill Leidy
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/13155371?v=3&s=460'}
+            %h4
+                Bryan Karlovitz
+        %div.contributor
+            %img{:src =>'https://avatars0.githubusercontent.com/u/1129042?v=3&s=460'}
+            %h4
+                Dan Turcza
+        %div.contributor
+            %img{:src =>'https://chihacknight.org/images/people/eve_tulbert.jpg'}
+            %h4
+                Eve Tulbert
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/13826498?v=3&s=460'}
+            %h4
+                Ezra Chang
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/2660212?v=3&s=460'}
+            %h4
+                Hillel Wayne
+        %div.contributor
+            %img{:src =>'https://avatars2.githubusercontent.com/u/19562265?v=3&s=460'}
+            %h4
+                Jared Ramsburg
+        %div.contributor
+            %img{:src =>'https://avatars3.githubusercontent.com/u/11065085?v=3&s=460'}
+            %h4
+                Jerliyah Craig
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/12823947?v=3&s=460'}
+            %h4
+                John
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/15352346?v=3&s=460'}
+            %h4
+                Jones Melton
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/8214544?v=3&s=460'}
+            %h4
+                Kevin Yaroch
+        %div.contributor
+            %img{:src =>'https://avatars2.githubusercontent.com/u/6394616?v=3&s=460'}
+            %h4
+                Mathew Liew
+        %div.contributor
+            %img{:src =>'https://avatars3.githubusercontent.com/u/1088319?v=3&s=460'}
+            %h4
+                Matt Harding
+        %div.contributor
+            %img{:src =>'https://avatars0.githubusercontent.com/u/1131802?v=3&s=460'}
+            %h4
+                Michael Hadley
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/11905743?v=3&s=460'}
+            %h4
+                Nick Wesley
+        %div.contributor
+            %img{:src =>'https://avatars1.githubusercontent.com/u/8291663?v=3&s=460'}
+            %h4
+                Patrick Sier
+        %div.contributor
+            %img{:src =>'https://avatars0.githubusercontent.com/u/10779838?v=3&s=460'}
+            %h4
+                Peter Macaluso
+        %div.contributor
+            %img{:src =>'https://chihacknight.org/images/people/vinesh_kannan.jpg'}
+            %h4
+                Vinesh Kannan

--- a/edumap/app/views/static_pages/about.html.haml
+++ b/edumap/app/views/static_pages/about.html.haml
@@ -1,7 +1,25 @@
 %div.about
+    %h1
+        What is EduMap?
+    %p
+        In 2016, Chicago Public Schools' CS4ALL program will put Computer Science education in every school, K-12. EduMap helps educators teaching CS for the first time find quality lesson plans to help their students learn. Lessons in EduMap are mapped to important educational standards, helping veteran CS teachers find modules to round out their curriculum.
+    %p
+        EduMap was created by the Teach Tech Taskforce, a group of citizens from ChiHackNight passionate about nurturing the next generation of technologists. Even if you're not in Chicago, let us know if EduMap helps you!
+    %h1
+        How can I help?
     %p
         Check us out on
         %a{:href => "https://github.com/andyras/edumap"} GitHub!
+        We are looking for:
+    %ul
+        %li
+            User-centered designers and teachers willing to test and iterate EduMap.
+        %li
+            Front-end developers and graphic designers to freshen up our user interface.
+        %li
+            Ruby on Rails developers to build functionality and help with our back-end.
+        %li
+            Programmers of any kind to help scrape and clean information about CS lesson plans.
     %h1
         Contributors
     %p


### PR DESCRIPTION
Here is some basic splash content for the about page. I just added placeholders for the first two sections, awaiting a better description. Preview screenshot:
![image](https://cloud.githubusercontent.com/assets/11896652/15529086/fc5c91ce-220f-11e6-91ff-fc8b0354672e.png)
I put styles for the about page in a section of the layout stylesheet: `edumap/app/assets/stylesheets/layout.scss` starting at line 150.
The HAML for the contributors section is generated by [this spreadsheet](https://docs.google.com/spreadsheets/d/16aSeip46LmZivrpiU-hKh5Q3Qr-gWZhSgc2n3a4sZJQ/edit#gid=0). Future contributors can be added here and it will generate the markup to be added to EduMap.