### PR TITLE
Changed lesson description location, implemented beginnings of displaying codes.

### DIFF
--- a/edumap/app/assets/javascripts/application.js
+++ b/edumap/app/assets/javascripts/application.js
@@ -34,11 +34,6 @@ let handleTableClass = () => {
     let compReq = document.getElementById('compReq');
     let sortOrder = document.getElementById('sortOrder');
 
-    console.log(stFilter.value);
-    console.log(grFilter.value);
-    console.log(compReq.value);
-    console.log(sortOrder.value);
-
     if (searchQuery.length > 0 || stFilter.value !== '' || grFilter.value !== '' || compReq.value !== '' || sortOrder.value !== 'created_at_desc') {
         tableResults.classList.remove('hidden-table');
         entryText.classList.add('hidden-table');

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -10,31 +10,43 @@
   %table.table
     %tr
       %th Select
+      %th &nbsp;
       %th Curriculum
       %th Lesson
       %th Time
       %th Level
     - lessons.each do |lesson|
-      %tr.accordion-toggle
+      -# %tr.accordion-toggle
+      %tr
         %td
           %input.lesson-checkbox{type: "checkbox", checked: in_session?("#{lesson.id}"), data: {lesson_id: "#{lesson.id}"}}
-        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.curriculum.name
-        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= link_to lesson.name, lesson.lesson_url, :target => "_blank"
-        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.time
-        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.level_list
-      %tr.accordion-body.collapse{:id => "#{lesson.id}"}
         %td
           - if lesson.plugged?
             %i.fa.fa-plug.fa-lg.plugged
           - else
             %i.fa.fa-plug.fa-lg.unplugged Unplugged
-        %td
+        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}
+          %h4{ :style => 'margin-top: 0px;'}= lesson.curriculum.name
           - if lesson.description
             %p= lesson.description
           - else
             %p No description is available for this lesson.
-        %td
-        %td
+        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= link_to lesson.name, lesson.lesson_url, :target => "_blank"
+        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.time
+        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.level_list
+      -# %tr.accordion-body.collapse{:id => "#{lesson.id}"}
+      -#   %td
+      -#     - if lesson.plugged?
+      -#       %i.fa.fa-plug.fa-lg.plugged
+      -#     - else
+      -#       %i.fa.fa-plug.fa-lg.unplugged Unplugged
+      -#   %td
+      -#     - if lesson.description
+      -#       %p= lesson.description
+      -#     - else
+      -#       %p No description is available for this lesson.
+      -#   %td
+      -#   %td
   .row.pagination-row
     .chardin_box.pull-left{ :'data-position' => 'top', :'data-intro' => "will_paginate's paginator works as expected." }
       = will_paginate lessons, renderer: BootstrapPagination::Rails

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -16,8 +16,7 @@
       %th Time
       %th Level
     - lessons.each do |lesson|
-      -# %tr.accordion-toggle
-      %tr
+      %tr.accordion-toggle
         %td
           %input.lesson-checkbox{type: "checkbox", checked: in_session?("#{lesson.id}"), data: {lesson_id: "#{lesson.id}"}}
         %td
@@ -34,19 +33,17 @@
         %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= link_to lesson.name, lesson.lesson_url, :target => "_blank"
         %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.time
         %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}= lesson.level_list
-      -# %tr.accordion-body.collapse{:id => "#{lesson.id}"}
-      -#   %td
-      -#     - if lesson.plugged?
-      -#       %i.fa.fa-plug.fa-lg.plugged
-      -#     - else
-      -#       %i.fa.fa-plug.fa-lg.unplugged Unplugged
-      -#   %td
-      -#     - if lesson.description
-      -#       %p= lesson.description
-      -#     - else
-      -#       %p No description is available for this lesson.
-      -#   %td
-      -#   %td
+      %tr.accordion-body.collapse{:id => "#{lesson.id}"}
+        %td
+        %td
+        %td
+          - (JSON.parse(lesson.codes.to_json)).each do |code|
+            %p= code["identifier"]
+            - if code["description"]
+              %p= code["description"]
+        %td
+        %td
+        %td
   .row.pagination-row
     .chardin_box.pull-left{ :'data-position' => 'top', :'data-intro' => "will_paginate's paginator works as expected." }
       = will_paginate lessons, renderer: BootstrapPagination::Rails


### PR DESCRIPTION
#73 

Here's what it looks like, now.
![screen shot 2016-05-27 at 3 45 33 pm](https://cloud.githubusercontent.com/assets/13826498/15620871/96daefa2-2422-11e6-97e9-601d72086112.png)

Several questions:

Do we see any scenario in which we'll have courses that don't require a computer?
If so, how does the styling look? I wanted to differentiate the curriculum name from its description.

Any feedback is appreciated.

Another note: I left the old markup in place, commented out, just in case we decide we want it back and don't want to dig through version control.