### PR TITLE
Match button colors

### DIFF
--- a/edumap/app/assets/stylesheets/layout.scss
+++ b/edumap/app/assets/stylesheets/layout.scss
@@ -219,3 +219,13 @@ div.contributor h4{
     margin: 20px;
   }
 }
+
+.btn-green {
+  background-color: #2A9E5A;
+  color: #FFFFFF;
+}
+
+.btn-green:hover {
+  background-color: #006B27;
+  color: #FFFFFF;
+}

--- a/edumap/app/assets/stylesheets/layout.scss
+++ b/edumap/app/assets/stylesheets/layout.scss
@@ -229,3 +229,7 @@ div.contributor h4{
   background-color: #006B27;
   color: #FFFFFF;
 }
+
+.modal-content {
+  border: 2px solid #2A9E5A;
+}

--- a/edumap/app/views/lessons/_email_form.html.haml
+++ b/edumap/app/views/lessons/_email_form.html.haml
@@ -13,5 +13,5 @@
               %label
                 = check_box_tag(:clear_lessons, nil, class: "form-control")
                 Clear saved lessons
-          = submit_tag "Send", class: "btn btn-primary"
+          = submit_tag "Send", class: "btn btn-green"
           = button_tag "Cancel", class: "btn btn-default", data: { dismiss: "modal" }

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -38,4 +38,4 @@
   .row.pagination-row
     .chardin_box.pull-left{ :'data-position' => 'top', :'data-intro' => "will_paginate's paginator works as expected." }
       = will_paginate lessons, renderer: BootstrapPagination::Rails
-    %button.btn.btn-primary.pull-right{ :'data-toggle' => "modal", :'data-target' => "#emailFormModal" } Email to Me
+    %button.btn.btn-green.pull-right{ :'data-toggle' => "modal", :'data-target' => "#emailFormModal" } Email to Me

--- a/edumap/app/views/lessons/index.html.haml
+++ b/edumap/app/views/lessons/index.html.haml
@@ -6,7 +6,7 @@
           .form-group.chardin_box{ :'data-position' => 'top', :'data-intro' => 'Search lessons.' }
             %label Search
             .pull-right{ :'data-position' => 'bottom', :'data-intro' => 'Reset the filter settings to defaults.' }
-              = link_to "Reset filters", reset_filterrific_url, :class => 'btn btn-default btn-sm', :id => 'wipe-results'
+              = link_to "Reset filters", reset_filterrific_url, :class => 'btn btn-green btn-sm', :id => 'wipe-results'
             .search
               %span.fa.fa-search
               = f.text_field :search_query,


### PR DESCRIPTION
Issue #100 - buttons now have the specified color. They darken 20% on mouseover. I also added a green border to the email dialog, as in the spec.

![screen shot 2016-05-31 at 8 08 42 pm](https://cloud.githubusercontent.com/assets/8214544/15695343/d8b311d8-276b-11e6-9ca2-98f21482e8f4.png)
![screen shot 2016-05-31 at 8 09 29 pm](https://cloud.githubusercontent.com/assets/8214544/15695346/dd5692e6-276b-11e6-984c-818893f1d944.png)
![screen shot 2016-05-31 at 8 08 59 pm](https://cloud.githubusercontent.com/assets/8214544/15695345/da6efec4-276b-11e6-9b9a-280874587236.png)
![screen shot 2016-05-31 at 8 08 26 pm](https://cloud.githubusercontent.com/assets/8214544/15695349/e526d3be-276b-11e6-84ec-7252615b627a.png)