### PR TITLE
Fixed column resizing on accordion expand/collapse

### DIFF
--- a/edumap/app/assets/stylesheets/lessons.scss
+++ b/edumap/app/assets/stylesheets/lessons.scss
@@ -9,3 +9,7 @@ tr.accordion-toggle {
 tr.selected {
   background-color: #DDEFE4;
 }
+
+tr.accordion-toggle td:last-child {
+  text-align: center;
+}

--- a/edumap/app/views/lessons/_list.html.haml
+++ b/edumap/app/views/lessons/_list.html.haml
@@ -1,5 +1,12 @@
 #table-results
   %table.table
+    %colgroup
+      %col{ :style => 'width:25%;'}
+      %col{ :style => 'width:40%;'}
+      %col{ :style => 'width:5%;'}
+      %col{ :style => 'width:10%;'}
+      %col{ :style => 'width:10%;'}
+      %col{ :style => 'width:10%;'}
     %tr
       %th Lesson
       %th Curriculum
@@ -16,7 +23,7 @@
             %p= lesson.description
           - else
             %p No description is available for this lesson.
-        %td
+        %td{ :'data-toggle' => 'collapse', :'data-target' => :"##{lesson.id}"}
           - if lesson.plugged?
             %i.fa.fa-plug.fa-lg.plugged
           - else
@@ -27,7 +34,7 @@
           %input.lesson-checkbox{type: "checkbox", checked: in_session?("#{lesson.id}"), data: {lesson_id: "#{lesson.id}"}}
       %tr.accordion-body.collapse{:id => "#{lesson.id}"}
         %td
-        %td
+        %td{ :colspan => '5'}
           - lesson.standards.uniq.each do |standard|
             %p
               %strong= standard.abbreviation
@@ -37,10 +44,6 @@
                   - if sc.identifier == lc.identifier
                     = lc.identifier
                     &nbsp;&nbsp;&nbsp;
-        %td
-        %td
-        %td
-        %td
   .row.pagination-row
     .chardin_box.pull-left{ :'data-position' => 'top', :'data-intro' => "will_paginate's paginator works as expected." }
       = will_paginate lessons, renderer: BootstrapPagination::Rails


### PR DESCRIPTION
Added `colgroup` tag setting table column widths (inline CSS only because it seemed much more clear for readability), as well as `colspan` attribute on section with standards codes so that it fills the rest of the space in the table. This should address #110. I also centered the checkbox in the select column, but that was just looking odd to me.

Here are screenshots of the same example used (Code.org 1.10)
![screen shot 2016-06-22 at 7 38 49 pm](https://cloud.githubusercontent.com/assets/8291663/16288474/cb098dc6-38b1-11e6-8d6a-a2b3fc897fe7.png)

![screen shot 2016-06-22 at 7 38 59 pm](https://cloud.githubusercontent.com/assets/8291663/16288475/cfdabfc8-38b1-11e6-9fd4-1a50be821743.png)


