### PR TITLE
Edit modal CSS for email popup

### DIFF
--- a/edumap/app/assets/stylesheets/layout.scss
+++ b/edumap/app/assets/stylesheets/layout.scss
@@ -4,6 +4,9 @@
 
 // default styles
 
+$dark-green: #2A9E5A;
+$light-green: #B9DFC9;
+
 html{
   overflow-x: hidden;
 }
@@ -37,7 +40,7 @@ a {
 }
 
 header, footer {
-  background-color: #B9DFC9;;
+  background-color: $light-green;
 }
 
 footer {
@@ -221,15 +224,11 @@ div.contributor h4{
 }
 
 .btn-green {
-  background-color: #2A9E5A;
+  background-color: $dark-green;
   color: #FFFFFF;
 }
 
 .btn-green:hover {
   background-color: #006B27;
   color: #FFFFFF;
-}
-
-.modal-content {
-  border: 2px solid #2A9E5A;
 }

--- a/edumap/app/assets/stylesheets/modal.scss
+++ b/edumap/app/assets/stylesheets/modal.scss
@@ -16,7 +16,7 @@ $dark-green: #2A9E5A;
     vertical-align: middle;
   }
   .form-control {
-    width: 80%;
-    display: inline;
+    max-width: 400px;
+    margin: auto;
   }
 }

--- a/edumap/app/assets/stylesheets/modal.scss
+++ b/edumap/app/assets/stylesheets/modal.scss
@@ -1,0 +1,22 @@
+$dark-green: #2A9E5A;
+
+.modal-content {
+  border: 2px solid $dark-green;
+}
+
+.modal {
+  top: 20%;
+}
+
+.centered {
+  text-align: center;
+  i {
+    color: $dark-green;
+    margin: .2em .1em;
+    vertical-align: middle;
+  }
+  .form-control {
+    width: 80%;
+    display: inline;
+  }
+}

--- a/edumap/app/views/lessons/_email_form.html.haml
+++ b/edumap/app/views/lessons/_email_form.html.haml
@@ -2,16 +2,19 @@
   .modal-dialog
     .modal-content
       .modal-body
-        %p You are about to email your saved lessons to yourself.
-        %p Enter your email address below and hit send.
-        = form_tag("sessions/send_lessons") do
-          .form-group
-            = label_tag(:email, "Email address")
-            = text_field_tag(:email, nil, class: "form-control")
-          .form-group
-            .checkbox
-              %label
-                = check_box_tag(:clear_lessons, nil, class: "form-control")
-                Clear saved lessons
-          = submit_tag "Send", class: "btn btn-green"
-          = button_tag "Cancel", class: "btn btn-default", data: { dismiss: "modal" }
+        .centered
+          %i.fa.fa-envelope-o.fa-4x
+          %i.fa.fa-arrow-right.fa-2x
+          %p You are about to email your saved lessons to yourself.
+          %p Enter your email address below and hit send.
+          = form_tag("sessions/send_lessons") do
+            .form-group
+              = label_tag(:email, "Email address")
+              = text_field_tag(:email, nil, class: "form-control")
+            .form-group
+              .checkbox
+                %label
+                  = check_box_tag(:clear_lessons, nil, class: "form-control")
+                  Clear saved lessons
+            = submit_tag "Send", class: "btn btn-green"
+            = button_tag "Cancel", class: "btn btn-default", data: { dismiss: "modal" }


### PR DESCRIPTION
I made a couple of visual changes to the email popup to better match the original design. 

![screen shot 2016-06-27 at 11 31 24 pm](https://cloud.githubusercontent.com/assets/13334214/16403923/a9be2e30-3cbf-11e6-9672-84c4092cf0c0.png)
